### PR TITLE
Configured application name for app1

### DIFF
--- a/app1/src/main/resources/config/application-dev.yml
+++ b/app1/src/main/resources/config/application-dev.yml
@@ -39,6 +39,8 @@ spring:
         cache-seconds: 1
     thymeleaf:
         cache: false
+    application:
+        name: app1
 
 liquibase:
     contexts: dev


### PR DESCRIPTION
@jdubois you just have to configure the spring.application.name in order to enable the context 'app1' to be configured. This pull request fixes #1 
